### PR TITLE
Fixes for 1.13.2 compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
         <java-version>1.6</java-version>
 
-        <bukkit-version>1.12.1-R0.1-SNAPSHOT</bukkit-version>
-        <spigot-version>1.12.1-R0.1-SNAPSHOT</spigot-version>
+        <bukkit-version>1.13.2-R0.1-SNAPSHOT</bukkit-version>
+        <spigot-version>1.13.2-R0.1-SNAPSHOT</spigot-version>
 
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/dpohvar/powernbt/nbt/NBTContainerItem.java
+++ b/src/main/java/me/dpohvar/powernbt/nbt/NBTContainerItem.java
@@ -22,7 +22,7 @@ public class NBTContainerItem extends NBTContainer<ItemStack> {
     @SuppressWarnings("deprecation")
     @Override
     public List<String> getTypes() {
-        int id = item.getTypeId();
+        int id = item.getType().getId();
         List<String> s = new ArrayList<String>();
         s.add("item");
         if (id == 387 || id == 386) s.add("item_book");

--- a/src/main/java/me/dpohvar/powernbt/utils/ItemStackUtils.java
+++ b/src/main/java/me/dpohvar/powernbt/utils/ItemStackUtils.java
@@ -96,7 +96,7 @@ public final class ItemStackUtils {
         if (asNMSCopy != null) {
             return asNMSCopy.call(itemStack);
         } else {
-            int type = itemStack.getTypeId();
+            int type = itemStack.getType().getId();
             int amount = itemStack.getAmount();
             int data = itemStack.getData().getData();
             return conNmsItemStack.create(type, amount, data);


### PR DESCRIPTION
Changed NBTBlockUtils and other files countains removed method.

On 1.13.2 update, method getTileEntityAt in CraftWorld is removed and replaced with getTileEntity in WorldServer(which is handle of CraftWorld). So I created constructor and changed getTileEntity method on NBTBlockUtils for backward compatibility.